### PR TITLE
Fix SHAP pipeline helper for breast cancer problem

### DIFF
--- a/solutions/problem2_breast_cancer.py
+++ b/solutions/problem2_breast_cancer.py
@@ -83,7 +83,15 @@ def _run_shap(best_result: ModelResult, X_train: pd.DataFrame, X_test: pd.DataFr
     background = shap.sample(X_train, 100, random_state=RANDOM_STATE)
     samples = X_test.sample(N_SAMPLES, random_state=RANDOM_STATE)
 
-    explainer = shap.KernelExplainer(best_result.model.predict_proba, background)
+    def _pipeline_proba(data):
+        if not isinstance(data, pd.DataFrame):
+            data = pd.DataFrame(data, columns=X_train.columns)
+        else:
+            # Ensure the columns are in the same order as training data
+            data = data[X_train.columns]
+        return best_result.model.predict_proba(data)
+
+    explainer = shap.KernelExplainer(_pipeline_proba, background)
     shap_values = explainer.shap_values(samples)
 
     mean_abs_shap = np.abs(shap_values[1]).mean(axis=0)


### PR DESCRIPTION
## Summary
- add a standalone helper for SHAP KernelExplainer to avoid bound method issues
- coerce SHAP inputs back to the training DataFrame layout so the scaler sees ordered features

## Testing
- python main.py problem2 --output-dir reports/problem2_test *(fails: environment uses NumPy 2.x but SHAP/torch expect NumPy 1.x)*

------
https://chatgpt.com/codex/tasks/task_e_68d725ec5b548331be7ddc41b50ba199