### PR TITLE
Handle missing normalization metadata for pretrained weights

### DIFF
--- a/solutions/problem4_pretrained.py
+++ b/solutions/problem4_pretrained.py
@@ -172,6 +172,39 @@ def _lime_for_images(
     return lime_summaries
 
 
+def _extract_normalization(preprocess, weights) -> tuple[torch.Tensor, torch.Tensor]:
+    """Return mean and std tensors used for normalization.
+
+    Some torchvision weights expose normalization statistics via their meta
+    dictionary, while others only provide them inside the composed preprocessing
+    pipeline.  Older code assumed the `meta` entries were always present, which
+    is no longer true for every release.  This helper inspects the transform
+    pipeline first and falls back to the metadata if needed so that we always
+    recover consistent statistics for de-normalising tensors before
+    visualisation.
+    """
+
+    normalize = None
+    transforms_seq = getattr(preprocess, "transforms", [])
+    for transform in transforms_seq:
+        if isinstance(transform, transforms.Normalize):
+            normalize = transform
+            break
+
+    if normalize is not None:
+        mean = torch.tensor(normalize.mean, device=DEVICE).view(3, 1, 1)
+        std = torch.tensor(normalize.std, device=DEVICE).view(3, 1, 1)
+        return mean, std
+
+    meta = getattr(weights, "meta", {}) or {}
+    if "mean" in meta and "std" in meta:
+        mean = torch.tensor(meta["mean"], device=DEVICE).view(3, 1, 1)
+        std = torch.tensor(meta["std"], device=DEVICE).view(3, 1, 1)
+        return mean, std
+
+    raise ValueError("Unable to determine normalization statistics from weights.")
+
+
 def _shap_for_images(
     model: nn.Module,
     weights,
@@ -206,8 +239,7 @@ def _shap_for_images(
         # shap returns values with channel-first ordering -> convert to HWC
         shap_values_np.append(np.transpose(arr, (0, 2, 3, 1)))
 
-    mean = torch.tensor(weights.meta["mean"], device=DEVICE).view(3, 1, 1)
-    std = torch.tensor(weights.meta["std"], device=DEVICE).view(3, 1, 1)
+    mean, std = _extract_normalization(preprocess, weights)
 
     shap_summaries = []
     for idx in range(batch.size(0)):


### PR DESCRIPTION
## Summary
- add a helper that extracts normalization statistics from either the transform pipeline or weight metadata
- fall back to the helper when preparing SHAP visualisations to avoid KeyError when metadata is absent

## Testing
- python main.py problem4 --output-dir experiment_outputs *(fails: environment installs numpy 2.x which is incompatible with shap/torch stack)*

------
https://chatgpt.com/codex/tasks/task_e_68d73ddc1c5c8331a366398cc8d4b275